### PR TITLE
[WIP] Make use of eloquent/phpstan-phony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/annotations": "^1.3.0",
         "eloquent/phony": "^2.0.0",
         "eloquent/phony-phpunit": "^3.0.0",
-        "eloquent/phpstan-phony": "dev-master",
+        "eloquent/phpstan-phony": "^0.1.0",
         "friendsofphp/php-cs-fixer": "^2.7.0@dev",
         "kdyby/annotations": "^2.3.0",
         "kdyby/doctrine-cache": "^2.6.1@dev",

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
         "doctrine/annotations": "^1.3.0",
         "eloquent/phony": "^2.0.0",
         "eloquent/phony-phpunit": "^3.0.0",
+        "eloquent/phpstan-phony": "dev-master",
         "friendsofphp/php-cs-fixer": "^2.7.0@dev",
         "kdyby/annotations": "^2.3.0",
         "kdyby/doctrine-cache": "^2.6.1@dev",
         "latte/latte": "^2.4.0",
-        "phpstan/phpstan": "^0.8.5",
-        "phpstan/phpstan-nette": "^0.8.3"
+        "phpstan/phpstan": "0.9.x-dev",
+        "phpstan/phpstan-nette": "0.9.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 includes:
     - vendor/phpstan/phpstan-nette/extension.neon
     - vendor/phpstan/phpstan-nette/rules.neon
-    - vendor/eloquent/phpstan-phony/etc/phpunit.neon
+    - vendor/eloquent/phpstan-phony/phony.neon
 
 parameters:
     excludes_analyse:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
         - %rootDir%/../../../tests/_*
 
     ignoreErrors:
-        - '#^Access to an undefined property Eloquent\\Phony\\Mock\\Handle\\InstanceHandle(<[^>]+>)?::\$[a-zA-Z]++#'
         - '#^Call to an undefined method Nette\\Application\\UI\\Presenter::getVerifier\(\)#'
         - '#^Call to protected method createRequest\(\) of class Nette\\Application\\UI\\Presenter#'
         - '#^Parameter \#1 \$code of method Tests\\Functional\\Classes\\ArticlePresenter::redirectVerified\(\) expects int, string given#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,18 +1,15 @@
 includes:
     - vendor/phpstan/phpstan-nette/extension.neon
     - vendor/phpstan/phpstan-nette/rules.neon
+    - vendor/eloquent/phpstan-phony/etc/phpunit.neon
 
 parameters:
     excludes_analyse:
         - %rootDir%/../../../tests/_*
 
     ignoreErrors:
-        - '#^Access to an undefined property Eloquent\\Phony\\Mock\\Handle\\InstanceHandle::\$[a-zA-Z]++#'
-        - '#^Parameter \#[0-9]++ \$[a-zA-Z]++ of class [a-zA-Z\\]++ constructor expects [a-zA-Z\\]++, Eloquent\\Phony\\Mock\\Mock given#'
-        - '#^Parameter \#[0-9]++ \$[a-zA-Z]++ of method [a-zA-Z\\:]++\(\) expects [a-zA-Z\\|]++, Eloquent\\Phony\\Mock\\Mock given#'
-        - '#^Method [a-zA-Z\\]++::[a-zA-Z]++\(\) should return [a-zA-Z\\]++ but returns Eloquent\\Phony\\Mock\\Mock#'
+        - '#^Access to an undefined property Eloquent\\Phony\\Mock\\Handle\\InstanceHandle(<[^>]+>)?::\$[a-zA-Z]++#'
         - '#^Call to an undefined method Nette\\Application\\UI\\Presenter::getVerifier\(\)#'
         - '#^Call to protected method createRequest\(\) of class Nette\\Application\\UI\\Presenter#'
-        - '#^Property Arachne\\Verifier\\Rules\\[a-zA-Z]++::\$rules \(Arachne\\Verifier\\RuleInterface\[\]\) does not accept Eloquent\\Phony\\Mock\\Mock\[\]#'
         - '#^Parameter \#1 \$code of method Tests\\Functional\\Classes\\ArticlePresenter::redirectVerified\(\) expects int, string given#'
         - '#^Calling method [a-zA-Z]++\(\) on possibly null value of type Nette\\Application\\UI\\Presenter\|null#'

--- a/src/Annotations/AnnotationsRuleProvider.php
+++ b/src/Annotations/AnnotationsRuleProvider.php
@@ -29,8 +29,6 @@ class AnnotationsRuleProvider implements RuleProviderInterface
     }
 
     /**
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $reflection
-     *
      * @return RuleInterface[]
      */
     public function getRules(Reflector $reflection): array

--- a/src/RuleProviderInterface.php
+++ b/src/RuleProviderInterface.php
@@ -15,8 +15,6 @@ use Reflector;
 interface RuleProviderInterface
 {
     /**
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $reflection
-     *
      * @return RuleInterface[]
      */
     public function getRules(Reflector $reflection): array;

--- a/src/Rules/AllRuleHandler.php
+++ b/src/Rules/AllRuleHandler.php
@@ -30,8 +30,6 @@ class AllRuleHandler implements RuleHandlerInterface
     }
 
     /**
-     * @param All $rule
-     *
      * @throws VerificationException
      */
     public function checkRule(RuleInterface $rule, Request $request, ?string $component = null): void

--- a/src/Rules/EitherRuleHandler.php
+++ b/src/Rules/EitherRuleHandler.php
@@ -30,8 +30,6 @@ class EitherRuleHandler implements RuleHandlerInterface
     }
 
     /**
-     * @param Either $rule
-     *
      * @throws VerificationException
      */
     public function checkRule(RuleInterface $rule, Request $request, ?string $component = null): void

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -52,8 +52,6 @@ class Verifier
     /**
      * Returns rules that are required for given reflection.
      *
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $reflection
-     *
      * @return RuleInterface[]
      */
     public function getRules(Reflector $reflection): array

--- a/tests/functional/src/Classes/BlockControl.php
+++ b/tests/functional/src/Classes/BlockControl.php
@@ -6,6 +6,7 @@ namespace Tests\Functional\Classes;
 
 use Arachne\Verifier\Application\VerifierControlTrait;
 use Nette\Application\UI\Control;
+use Nette\Application\UI\ITemplate;
 
 /**
  * @author Jáchym Toušek <enumag@gmail.com>
@@ -23,8 +24,12 @@ class BlockControl extends Control
     public function render(): void
     {
         $this->getTemplate()->privilege = $this->privilege;
-        $this->template->setFile(__DIR__.'/../../templates/block.latte');
-        $this->template->render();
+
+        /** @var ITemplate $template */
+        $template = $this->template;
+
+        $template->setFile(__DIR__.'/../../templates/block.latte');
+        $template->render();
     }
 
     /**

--- a/tests/functional/src/ExceptionsTest.php
+++ b/tests/functional/src/ExceptionsTest.php
@@ -32,10 +32,11 @@ class ExceptionsTest extends Unit
             ]
         );
 
+        /** @var IPresenterFactory $presenterFactory */
+        $presenterFactory = $this->tester->grabService(IPresenterFactory::class);
+
         /** @var Presenter $presenter */
-        $presenter = $this->tester
-            ->grabService(IPresenterFactory::class)
-            ->createPresenter('Article');
+        $presenter = $presenterFactory->createPresenter('Article');
 
         // Canonicalization is broken in CLI.
         $presenter->autoCanonicalize = false;

--- a/tests/functional/src/RuleHandlersTest.php
+++ b/tests/functional/src/RuleHandlersTest.php
@@ -28,7 +28,9 @@ class RuleHandlersTest extends Unit
 
     public function _before(): void
     {
-        $this->verifier = $this->tester->grabService(Verifier::class);
+        /** @var Verifier $verifier */
+        $verifier = $this->tester->grabService(Verifier::class);
+        $this->verifier = $verifier;
     }
 
     public function testEitherFirst(): void


### PR DESCRIPTION
**NOTE:** This is a work in progress, do not merge.

I wanted to give you a preview of some progress I've made on [eloquent/phpstan-phony]. So far, mocking type inference seems to work pretty well for this project :)

This PR:

- Updates `composer.json` to use PHPStan `0.9.x-dev`, which is necessary to support [eloquent/phpstan-phony].
- Attempts to fix some analyse errors that (I think) are new in PHPStan `0.9.x-dev`.
- Adds [eloquent/phpstan-phony] to the Composer dev dependencies.
- Removes PHPStan ignore rules for analyse errors that no longer occur.
- <del>Updates the PHPStan rule to do with undefined properties on Phony `InstanceHandle` objects. This is the next feature I'll try to tackle in [eloquent/phpstan-phony].</del> **Done.**
- Removes some docblocks that were causing analyse errors, in the case where:
  - The docblock was more restrictive than the type hint; and
  - There were tests calling the documented method with a mocked type that did not match the docblock, but which was allowed by the type hint.

With all these changes, I managed to fix all but one analyse error:

```
 ------ --------------------------------------------------------
  Line   tests/functional/src/ExceptionsTest.php
 ------ --------------------------------------------------------
  63     Call to an undefined method object::createPresenter().
 ------ --------------------------------------------------------
```

I think this last one is a PHPStan bug and nothing to do with [eloquent/phpstan-phony] - it seems to be ignoring a `/** @var */` comment for some reason.

I will add more detail in comments on the PR code, but let me know what you think so far!

[eloquent/phpstan-phony]: https://github.com/eloquent/phpstan-phony